### PR TITLE
In MaterializeAction replace [any] by any[]

### DIFF
--- a/src/materialize-directive.ts
+++ b/src/materialize-directive.ts
@@ -29,7 +29,7 @@ declare var Materialize: any;
 
 export interface MaterializeAction {
     action: string;
-    params: [any];
+    params: any[];
 }
 
 @Directive({


### PR DESCRIPTION
[any] only has 1 element in its array.
any[] can has multiple elements.

It allows things like 
this.tabsActions.emit({action: "tabs", params: ['select_tab', page]}); that several persons were looking for, and it's compatible with previous version.